### PR TITLE
Add requirements.txt; Add pure-python-adb for cross-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # adbp
-A python script to make working with proxies on your Android devices _much_ easier!
+A Python script to make working with proxies on your Android devices _much_ easier!
 
 ----
 
 # Installation
 
-Pre-Requisites:
+### Pre-Requisites
 
 *  [adb](https://developer.android.com/studio/command-line/adb)
 *  [Python 3](https://www.python.org/downloads/)
-*  [Click](https://click.palletsprojects.com/en/8.0.x/) - `pip install click`
+
+### Install packages
+
+```
+pip install -r requirements.txt
+```
 
 # Usage
 

--- a/adbp.py
+++ b/adbp.py
@@ -1,7 +1,15 @@
-import click
-import subprocess
+#!/usr/bin/env python3
 
-##################################################################### 
+import click
+import socket
+
+from ppadb.client import Client as AdbClient
+
+# Globals #
+ADB_HOST = "127.0.0.1"
+ADB_PORT = 5037
+
+####################################################################
 
 @click.group()
 def adbp():
@@ -20,7 +28,7 @@ def remove(serial):
 def add(serial, ip, port):
     """Enables a proxy on connected devices via adb"""
     if ip == '':
-        ip = run_cmd('ipconfig getifaddr en0', lambda: click.echo('Using default IP'))[1]
+        ip = get_local_ip(lambda: click.echo('Using default IP'))
     apply_rule(serial, ip, port)
 
 ##################################################################### 
@@ -33,32 +41,49 @@ def apply_rule(serial, ip, port):
     else:
         # Multi-device rule
         for device in get_devices():
-            create_proxy(device, ip, port)
+            create_proxy(device.serial, ip, port)
 
 
 # Return a sanitised list of connected devices
 def get_devices():
-    cmd = 'adb devices | grep device | grep -v devices | awk \'{print$1}\''
-    result_code, output = run_cmd(cmd)
-    return output.split("\n")
+    client = AdbClient(host=ADB_HOST, port=ADB_PORT)
+    return client.devices()
 
 # Create proxy via adb
 def create_proxy(serial, ip, port):
     click.echo('Creating proxy rule for %s %s:%d' % (serial, ip, port))
-    cmd = 'adb -s %s shell settings put global http_proxy %s:%d' % (serial, ip, port)
-    return run_cmd(cmd, lambda: click.echo('Success'))
+    cmd = 'settings put global http_proxy %s:%d' % (ip, port)
+    return run_cmd(cmd, serial, lambda: click.echo('Success'))
 
 # Run a term command
-def run_cmd(cmd, func = lambda: ()):
-    result_code, output = subprocess.getstatusoutput(cmd)
-    if result_code != 0:
+def run_cmd(cmd, serial, func = lambda: ()):
+    client = AdbClient(host=ADB_HOST, port=ADB_PORT)
+    device = client.device(serial)
+    output = device.shell(cmd)
+    
+    if output != '':
         show_error(output)
     else:
         func()
-    return result_code, output
+
+    return output 
 
 def show_error(msg):
     click.echo('*** Error %s ***' % msg)
 
+def get_local_ip(func = lambda: ()):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('10.255.255.255', 1))
+        local_ip = s.getsockname()[0]
+    except Exception:
+        local_ip = '127.0.0.1'
+        show_error("Local IP Address is set to localhost(%s)" % (local_ip))
+    finally:
+        s.close()
+        func()
+    return local_ip
+
 if __name__ == '__main__':
     adbp()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+click==8.0.1
+pure_python_adb==0.3.0.dev0


### PR DESCRIPTION
* Added `requirements.txt`
* New function `get_local_ip()` that returns the computer's local IP address using `socket`, so should be cross-platform
* Introduced [pure-python-adb](https://github.com/Swind/pure-python-adb) and did away with using `subproces`

This should resolve #1 in regards to cross-compatibility, but should probably be tested a bit more than what I did. I'm running Windows 11 insider preview for ARM on an M1 Macbook Air with x86 Python3 installed and a janky ADB setup, so, if someone else wants to Cherry-Pick this before I get a chance to test it on a "real" Windows machine, that would be helpful. Can confirm works in Ubuntu just fine (tested on 20.04 Server - x86-64)

